### PR TITLE
Add wildcard matching to Router

### DIFF
--- a/lib/cotton_tail.rb
+++ b/lib/cotton_tail.rb
@@ -9,6 +9,7 @@ module CottonTail
   autoload :DSL, 'cotton_tail/dsl'
   autoload :Middleware, 'cotton_tail/middleware'
   autoload :Queue, 'cotton_tail/queue'
+  autoload :Route, 'cotton_tail/route'
   autoload :Router, 'cotton_tail/router'
   autoload :Version, 'cotton_tail/version'
 
@@ -27,6 +28,9 @@ module CottonTail
   end
 
   Response = Struct.new(:body)
+
+  class RouteConflictError < StandardError
+  end
 
   class UndefinedRouteError < StandardError
   end

--- a/lib/cotton_tail/dsl/routes.rb
+++ b/lib/cotton_tail/dsl/routes.rb
@@ -43,7 +43,7 @@ module CottonTail
 
       def handle(key, handler = nil, &block)
         handler ||= block
-        handlers[key] = handler
+        handlers[Route.new(key)] = handler
       end
 
       def handlers

--- a/lib/cotton_tail/middleware.rb
+++ b/lib/cotton_tail/middleware.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'middleware'
-require 'logger'
 
 module CottonTail
   # Top level namespace for Middleware

--- a/lib/cotton_tail/middleware/router.rb
+++ b/lib/cotton_tail/middleware/router.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'json'
+
 module CottonTail
   module Middleware
     # Router Middleware
@@ -18,12 +20,25 @@ module CottonTail
 
       private
 
-      def handler(route)
-        handlers.fetch(route) { raise UndefinedRouteError }
+      def route(routing_key)
+        CottonTail::Route.new(routing_key)
       end
 
       def response(routing_key, message)
         CottonTail::Response.new handler(routing_key).call(message)
+      end
+
+      def routes(routing_key)
+        handlers.keys.select { |route| route.match? routing_key }
+      end
+
+      def handler(routing_key)
+        route, *conflicts = routes(routing_key)
+        raise UndefinedRouteError if route.nil?
+
+        raise RouteConflictError unless conflicts.empty?
+
+        handlers[route]
       end
     end
   end

--- a/lib/cotton_tail/route.rb
+++ b/lib/cotton_tail/route.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module CottonTail
+  # Route value object
+  class Route
+    attr_reader :pattern
+
+    def initialize(pattern)
+      @pattern = pattern
+    end
+
+    def match?(routing_key)
+      return true if @pattern == routing_key
+
+      regex.match? routing_key
+    end
+
+    def to_s
+      @pattern
+    end
+
+    private
+
+    def regex
+      @regex ||= Regexp.new build_regex(@pattern)
+    end
+
+    def build_regex(pattern)
+      [
+        '^',
+        pattern.gsub('*', '([^.]+)').gsub(/\.?#\.?/, '([^.]{0,}\.?)+'),
+        '$'
+      ].join
+    end
+  end
+end

--- a/lib/cotton_tail/version.rb
+++ b/lib/cotton_tail/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CottonTail
-  VERSION = '0.4.1'
+  VERSION = '0.5.0'
 end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+module CottonTail
+  describe Route do
+    subject(:route) { described_class.new(pattern) }
+
+    describe '.match?' do
+      context 'given an exchange_type: :topic' do
+        let(:opts) { { exchange_type: :topic } }
+
+        describe 'exact matches' do
+          let(:pattern) { 'a.b.c' }
+
+          it 'behaves as expected' do
+            expect(route.match?('a.b.c')).to be true
+            expect(route.match?('a.b.c.d')).to be false
+            expect(route.match?('a.b')).to be false
+            expect(route.match?('b.c')).to be false
+          end
+        end
+
+        describe 'wildcard matches' do
+          describe 'segment wildcard at end' do
+            let(:pattern) { 'a.b.*' }
+
+            it 'behaves as expected' do
+              expect(route.match?('a.b.c')).to be true
+              expect(route.match?('a.b.z')).to be true
+              expect(route.match?('a.b')).to be false
+              expect(route.match?('a.b.c.d')).to be false
+            end
+          end
+
+          describe 'segment wildcard at start' do
+            let(:pattern) { '*.b.c' }
+
+            it 'behaves as expected' do
+              expect(route.match?('a.b.c')).to be true
+              expect(route.match?('z.b.c')).to be true
+              expect(route.match?('b.c')).to be false
+              expect(route.match?('a.b.z')).to be false
+            end
+          end
+
+          describe 'multiple segment wildcards' do
+            let(:pattern) { '*.b.*.d' }
+
+            it 'behaves as expected' do
+              expect(route.match?('a.b.c.d')).to be true
+              expect(route.match?('z.b.x.d')).to be true
+              expect(route.match?('a.b.c')).to be false
+              expect(route.match?('b.c.d')).to be false
+            end
+          end
+
+          describe 'group wildcard at start' do
+            let(:pattern) { '#.d' }
+
+            it 'behaves as expected' do
+              expect(route.match?('c.d')).to be true
+              expect(route.match?('a.b.c.d')).to be true
+              expect(route.match?('d.e')).to be false
+              expect(route.match?('a.b.c')).to be false
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add the ability to define handlers using wildcards.

```ruby
CottonTail::App.new.routes.draw do
  queue 'service_inbox' do
    handle 'service.events.*' do |env, req, res|
      puts "received: #{req.routing_key}"
    end
  end
end
```