### PR TITLE
Add route params

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,5 @@
 --format documentation
 --color
 --require spec_helper
+--require integration_helper
 -I integration

--- a/examples/app.rb
+++ b/examples/app.rb
@@ -25,6 +25,11 @@ app.routes.draw do
       puts request: request
       puts response: response
     end
+
+    handle 'send.*:gift.to.*:name' do |_env, request, _response|
+      gift, name = request.route_params.values_at('gift', 'name')
+      puts "#{gift} sent to #{name}!"
+    end
   end
 
   queue 'require_ack_queue', exclusive: true, manual_ack: true do

--- a/examples/messages/send.kitten.to.tom
+++ b/examples/messages/send.kitten.to.tom
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+read -r -d '' MESSAGE << EOM
+{
+  "properties":{},
+  "routing_key":"send.kitten.to.tom",
+  "payload": "ignored",
+  "payload_encoding": "string"
+}
+EOM
+
+curl -i -XPOST -d"${MESSAGE}" http://guest:guest@localhost:15672/api/exchanges/%2f/amq.topic/publish

--- a/integration/app_spec.rb
+++ b/integration/app_spec.rb
@@ -27,15 +27,26 @@ module CottonTail
 
     describe 'queue bindings' do
       it 'creates a binding for each handled route' do
-        routing_key = 'some.topic.routing.key'
+        pattern = 'some.topic.routing.key'
 
         app.routes.draw do
           queue queue_name do
-            handle routing_key, null_handler
+            handle pattern, null_handler
           end
         end
 
-        expect(queue_name).to have_bindings(routing_key)
+        expect(queue_name).to have_bindings(pattern)
+      end
+
+      it 'binds named wildcards correctly' do
+        app.routes.draw do
+          queue queue_name do
+            handle '*:a.*:b.*:c', null_handler
+            handle 'domain.#:resources.fetch', null_handler
+          end
+        end
+
+        expect(queue_name).to have_bindings('*.*.*', 'domain.#.fetch')
       end
     end
 

--- a/integration/dsl_integration_spec.rb
+++ b/integration/dsl_integration_spec.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
 def build_request(routing_key, payload)
-  CottonTail::Request.new({ routing_key: routing_key }, {}, payload)
+  delivery_info = OpenStruct.new(routing_key: routing_key)
+  CottonTail::Request.new(delivery_info, {}, payload)
 end
 
 module CottonTail

--- a/integration/integration_helper.rb
+++ b/integration/integration_helper.rb
@@ -4,6 +4,7 @@ require 'bundler/setup'
 require 'cotton_tail'
 require 'rspec'
 require 'support/rabbitmq_api_context'
+require 'ostruct'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure

--- a/integration/queue/bunny_spec.rb
+++ b/integration/queue/bunny_spec.rb
@@ -11,9 +11,10 @@ module CottonTail
 
       describe 'push and pulling' do
         let(:routing_key) { 'some.routing.key' }
+        let(:delivery_info) { instance_double(::Bunny::DeliveryInfo, routing_key: routing_key) }
 
         it 'works as expected' do
-          queue.push CottonTail::Request.new({ routing_key: routing_key }, {}, 'hello')
+          queue.push CottonTail::Request.new(delivery_info, {}, 'hello')
 
           message = queue.pop
           expect(message).to be_a Request

--- a/lib/cotton_tail.rb
+++ b/lib/cotton_tail.rb
@@ -10,6 +10,7 @@ module CottonTail
   autoload :Middleware, 'cotton_tail/middleware'
   autoload :Queue, 'cotton_tail/queue'
   autoload :Route, 'cotton_tail/route'
+  autoload :RouteSegment, 'cotton_tail/route_segment'
   autoload :Router, 'cotton_tail/router'
   autoload :Version, 'cotton_tail/version'
 

--- a/lib/cotton_tail.rb
+++ b/lib/cotton_tail.rb
@@ -7,26 +7,14 @@ module CottonTail
   autoload :App, 'cotton_tail/app'
   autoload :Configuration, 'cotton_tail/configuration'
   autoload :DSL, 'cotton_tail/dsl'
+  autoload :MessageProperties, 'cotton_tail/message_properties'
   autoload :Middleware, 'cotton_tail/middleware'
   autoload :Queue, 'cotton_tail/queue'
+  autoload :Request, 'cotton_tail/request'
   autoload :Route, 'cotton_tail/route'
   autoload :RouteSegment, 'cotton_tail/route_segment'
   autoload :Router, 'cotton_tail/router'
   autoload :Version, 'cotton_tail/version'
-
-  Request = Struct.new(:delivery_info, :properties, :payload) do
-    def routing_key
-      delivery_info[:routing_key]
-    end
-
-    def delivery_tag
-      delivery_info[:delivery_tag]
-    end
-
-    def channel
-      delivery_info[:channel]
-    end
-  end
 
   Response = Struct.new(:body)
 

--- a/lib/cotton_tail/dsl/queue.rb
+++ b/lib/cotton_tail/dsl/queue.rb
@@ -10,9 +10,9 @@ module CottonTail
         @context = context
       end
 
-      def handle(key, handler = nil, &block)
-        bind(key)
-        @context.handle(key, handler, &block)
+      def handle(pattern, handler = nil, &block)
+        bind pattern
+        @context.handle(pattern, handler, &block)
       end
 
       def topic(routing_prefix, &block)
@@ -20,10 +20,10 @@ module CottonTail
         topic.instance_eval(&block)
       end
 
-      def bind(key)
+      def bind(pattern)
         return unless @queue.respond_to?(:bind)
 
-        @queue.bind key
+        @queue.bind pattern
       end
     end
   end

--- a/lib/cotton_tail/message_properties.rb
+++ b/lib/cotton_tail/message_properties.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module CottonTail
+  # Wrapper around Bunny MessageProperties, used to supply route params
+  class MessageProperties < Bunny::MessageProperties
+    def merge(properties)
+      self.class.new(@properties.merge(properties))
+    end
+
+    def route_params
+      @properties[:route_params]
+    end
+
+    def ==(other)
+      to_h == other.to_h
+    end
+  end
+end

--- a/lib/cotton_tail/middleware/router.rb
+++ b/lib/cotton_tail/middleware/router.rb
@@ -15,30 +15,50 @@ module CottonTail
 
       def call(message)
         env, req, = message
-        @app.call [env, req, response(req.routing_key, message)]
+        @app.call [env, req, response(*message)]
       end
 
       private
 
-      def route(routing_key)
-        CottonTail::Route.new(routing_key)
-      end
+      def response(env, req, res)
+        routing_key = req.routing_key
+        handler = lookup_handler(routing_key)
+        route = lookup_route(routing_key)
+        req = add_route_params(req, route) if route_params?(route, routing_key)
 
-      def response(routing_key, message)
-        CottonTail::Response.new handler(routing_key).call(message)
+        CottonTail::Response.new handler.call([env, req, res])
       end
 
       def routes(routing_key)
         handlers.keys.select { |route| route.match? routing_key }
       end
 
-      def handler(routing_key)
+      def lookup_handler(routing_key)
+        handlers[lookup_route(routing_key)]
+      end
+
+      def lookup_route(routing_key)
         route, *conflicts = routes(routing_key)
         raise UndefinedRouteError if route.nil?
 
         raise RouteConflictError unless conflicts.empty?
 
-        handlers[route]
+        route
+      end
+
+      def add_route_params(req, route)
+        delivery_info, properties, payload = req.to_a
+        Request.new(
+          delivery_info,
+          properties.merge(
+            route_params: route.extract_params(req.routing_key)
+          ),
+          payload
+        )
+      end
+
+      def route_params?(route, routing_key)
+        route.extract_params(routing_key) == {} || true
       end
     end
   end

--- a/lib/cotton_tail/queue/bunny.rb
+++ b/lib/cotton_tail/queue/bunny.rb
@@ -35,7 +35,7 @@ module CottonTail
       end
 
       def bind(routing_key)
-        source.bind('amq.topic', routing_key: routing_key)
+        source.bind('amq.topic', routing_key: Route.new(routing_key).binding)
       end
 
       private

--- a/lib/cotton_tail/queue/bunny.rb
+++ b/lib/cotton_tail/queue/bunny.rb
@@ -30,7 +30,8 @@ module CottonTail
       end
 
       def pop
-        Request.new(*super)
+        delivery_info, properties, payload = super
+        Request.new(delivery_info, MessageProperties.new(properties.to_h), payload)
       end
 
       def bind(routing_key)

--- a/lib/cotton_tail/request.rb
+++ b/lib/cotton_tail/request.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module CottonTail
+  # Value object wrapper for Bunny Message
+  class Request
+    extend Forwardable
+
+    attr_reader :delivery_info, :properties, :payload
+
+    def initialize(delivery_info, properties, payload)
+      @delivery_info = delivery_info
+      @properties = properties
+      @payload = payload
+    end
+
+    def to_a
+      [delivery_info, properties, payload]
+    end
+
+    def to_h
+      {
+        delivery_info: delivery_info,
+        properties: properties,
+        payload: payload
+      }
+    end
+
+    def ==(other)
+      to_h == other.to_h
+    end
+
+    def_delegators :delivery_info, :routing_key, :delivery_tag, :channel
+    def_delegators :properties, :route_params
+  end
+end

--- a/lib/cotton_tail/route.rb
+++ b/lib/cotton_tail/route.rb
@@ -19,18 +19,26 @@ module CottonTail
       @pattern
     end
 
+    def wildcard_names
+      regex.names
+    end
+
     private
 
     def regex
       @regex ||= Regexp.new build_regex(@pattern)
     end
 
+    def regex_def(pattern)
+      segments(pattern).map(&:to_regex).join('\.')
+    end
+
+    def segments(pattern)
+      pattern.split('.').map(&RouteSegment.method(:new))
+    end
+
     def build_regex(pattern)
-      [
-        '^',
-        pattern.gsub('*', '([^.]+)').gsub(/\.?#\.?/, '([^.]{0,}\.?)+'),
-        '$'
-      ].join
+      ['^', regex_def(pattern), '$'].join
     end
   end
 end

--- a/lib/cotton_tail/route.rb
+++ b/lib/cotton_tail/route.rb
@@ -19,8 +19,21 @@ module CottonTail
       pattern.split('.')
     end
 
+    def collapse(segments)
+      segments.zip(separators(segments)).join
+    end
+
+    def separators(segments)
+      separators = segments.each_with_index.map do |segment, idx|
+        [Regexp.escape('.')].tap do |sep|
+          sep << '?' if segment.hash? && idx.zero?
+        end
+      end
+      separators.map(&:join)[0..-2]
+    end
+
     def definition(pattern)
-      segments(pattern).join Regexp.escape('.')
+      collapse segments(pattern)
     end
 
     def segments(pattern)

--- a/lib/cotton_tail/route_segment.rb
+++ b/lib/cotton_tail/route_segment.rb
@@ -16,6 +16,14 @@ module CottonTail
       /^#{HASH}|#{NAMED_HASH}$/.match? @value
     end
 
+    def binding
+      return '*' if star?
+
+      return '#' if hash?
+
+      @value
+    end
+
     private
 
     TRANSFORM = ->(val, func) { func.call(val) }

--- a/lib/cotton_tail/route_segment.rb
+++ b/lib/cotton_tail/route_segment.rb
@@ -4,7 +4,16 @@ module CottonTail
   # RouteSegment implements the pattern matching for route segments
   class RouteSegment < SimpleDelegator
     def initialize(value)
+      @value = value
       super Regexp.new definition(value)
+    end
+
+    def star?
+      /^#{STAR}|#{NAMED_STAR}$/.match? @value
+    end
+
+    def hash?
+      /^#{HASH}|#{NAMED_HASH}$/.match? @value
     end
 
     private
@@ -18,21 +27,21 @@ module CottonTail
     # Converts named route segment to Regexp named capture group
     #   "#:foo" -> "(?<foo>.+)"
     def sub_named_group_wildcard(pattern)
-      pattern.gsub(/#:(\w+)/, '(?<\1>.+)')
+      pattern.gsub(NAMED_HASH, '(?<\1>.+)')
     end
 
     # Converts named route segment to Regexp named capture group
     #   "*:foo" -> "(?<foo>[^.]+)"
     def sub_named_single_wildcard(pattern)
-      pattern.gsub(/\*:(\w+)/, '(?<\1>[^.]+)')
+      pattern.gsub(NAMED_STAR, '(?<\1>[^.]+)')
     end
 
     def sub_single_wildcard(pattern)
-      pattern.gsub('*', '([^.]+)')
+      pattern.gsub(STAR, '([^.]+)')
     end
 
     def sub_multi_wildcard(pattern)
-      pattern.gsub(/\.?#\.?/, '([^.]{0,}\.?)+')
+      pattern.gsub(HASH, '([^.]{0,}\.?)+')
     end
 
     def transformers
@@ -43,5 +52,11 @@ module CottonTail
         method(:sub_multi_wildcard)
       ]
     end
+
+    STAR = /\*/.freeze
+    HASH = /#/.freeze
+    NAMED = /:(\w+)/.freeze
+    NAMED_STAR = /#{STAR}#{NAMED}/.freeze
+    NAMED_HASH = /#{HASH}#{NAMED}/.freeze
   end
 end

--- a/lib/cotton_tail/route_segment.rb
+++ b/lib/cotton_tail/route_segment.rb
@@ -18,7 +18,7 @@ module CottonTail
     end
 
     def replace_named_captures(pattern)
-      pattern.gsub(/\*:(\w+)/, '(?<\1>[^.]+)')
+      pattern.gsub(/[*#]:(\w+)/, '(?<\1>[^.]+)')
     end
 
     def replace_single_wildcard(pattern)

--- a/lib/cotton_tail/route_segment.rb
+++ b/lib/cotton_tail/route_segment.rb
@@ -1,39 +1,46 @@
 # frozen_string_literal: true
 
 module CottonTail
-  # RouteSegment represents an individual segment of a CottonTail route
-  class RouteSegment
+  # RouteSegment implements the pattern matching for route segments
+  class RouteSegment < SimpleDelegator
     def initialize(value)
-      @value = value
-    end
-
-    def to_regex
-      Regexp.new regex_def
+      super Regexp.new definition(value)
     end
 
     private
 
-    def regex_def
-      replacers.inject(@value) { |val, replacer| replacer.call(val) }
+    TRANSFORM = ->(val, func) { func.call(val) }
+
+    def definition(value)
+      transformers.reduce(value, &TRANSFORM)
     end
 
-    def replace_named_captures(pattern)
-      pattern.gsub(/[*#]:(\w+)/, '(?<\1>[^.]+)')
+    # Converts named route segment to Regexp named capture group
+    #   "#:foo" -> "(?<foo>.+)"
+    def sub_named_group_wildcard(pattern)
+      pattern.gsub(/#:(\w+)/, '(?<\1>.+)')
     end
 
-    def replace_single_wildcard(pattern)
+    # Converts named route segment to Regexp named capture group
+    #   "*:foo" -> "(?<foo>[^.]+)"
+    def sub_named_single_wildcard(pattern)
+      pattern.gsub(/\*:(\w+)/, '(?<\1>[^.]+)')
+    end
+
+    def sub_single_wildcard(pattern)
       pattern.gsub('*', '([^.]+)')
     end
 
-    def replace_multi_wildcard(pattern)
+    def sub_multi_wildcard(pattern)
       pattern.gsub(/\.?#\.?/, '([^.]{0,}\.?)+')
     end
 
-    def replacers
+    def transformers
       [
-        method(:replace_named_captures),
-        method(:replace_single_wildcard),
-        method(:replace_multi_wildcard)
+        method(:sub_named_group_wildcard),
+        method(:sub_named_single_wildcard),
+        method(:sub_single_wildcard),
+        method(:sub_multi_wildcard)
       ]
     end
   end

--- a/lib/cotton_tail/route_segment.rb
+++ b/lib/cotton_tail/route_segment.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module CottonTail
+  # RouteSegment represents an individual segment of a CottonTail route
+  class RouteSegment
+    def initialize(value)
+      @value = value
+    end
+
+    def to_regex
+      Regexp.new regex_def
+    end
+
+    private
+
+    def regex_def
+      replacers.inject(@value) { |val, replacer| replacer.call(val) }
+    end
+
+    def replace_named_captures(pattern)
+      pattern.gsub(/\*:(\w+)/, '(?<\1>[^.]+)')
+    end
+
+    def replace_single_wildcard(pattern)
+      pattern.gsub('*', '([^.]+)')
+    end
+
+    def replace_multi_wildcard(pattern)
+      pattern.gsub(/\.?#\.?/, '([^.]{0,}\.?)+')
+    end
+
+    def replacers
+      [
+        method(:replace_named_captures),
+        method(:replace_single_wildcard),
+        method(:replace_multi_wildcard)
+      ]
+    end
+  end
+end

--- a/spec/request_spec.rb
+++ b/spec/request_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module CottonTail
+  describe Request do
+    subject(:request) { described_class.new(delivery_info, properties, payload) }
+
+    let(:delivery_info) { instance_double(Bunny::DeliveryInfo) }
+    let(:properties) { MessageProperties.new({}) }
+    let(:payload) { {} }
+
+    describe '.routing_key' do
+      subject { request.routing_key }
+
+      before do
+        allow(delivery_info).to receive(:routing_key) { 'some-key' }
+      end
+
+      it { is_expected.to eql 'some-key' }
+    end
+
+    describe '.delivery_tag' do
+      subject { request.delivery_tag }
+
+      before do
+        allow(delivery_info).to receive(:delivery_tag) { 'some-tag' }
+      end
+
+      it { is_expected.to eql 'some-tag' }
+    end
+
+    describe '.channel' do
+      subject { request.channel }
+
+      before do
+        allow(delivery_info).to receive(:channel) { 'some-channel' }
+      end
+
+      it { is_expected.to eql 'some-channel' }
+    end
+
+    describe '.route_params' do
+      subject { request.route_params }
+
+      let(:properties) { MessageProperties.new(route_params: { 'foo' => 'bar' }) }
+
+      it { is_expected.to eql properties[:route_params] }
+    end
+  end
+end

--- a/spec/route_segment_spec.rb
+++ b/spec/route_segment_spec.rb
@@ -4,6 +4,44 @@ module CottonTail
   describe RouteSegment do
     subject(:segment) { described_class.new(definition) }
 
+    describe '.star?' do
+      subject { segment.star? }
+
+      context 'given "*"' do
+        let(:definition) { '*' }
+        it { is_expected.to be true }
+      end
+
+      context 'given "*:named"' do
+        let(:definition) { '*:named' }
+        it { is_expected.to be true }
+      end
+
+      context 'given anything else' do
+        let(:definition) { 'hel*o' }
+        it { is_expected.to be false }
+      end
+    end
+
+    describe '.hash?' do
+      subject { segment.hash? }
+
+      context 'given "#"' do
+        let(:definition) { '#' }
+        it { is_expected.to be true }
+      end
+
+      context 'given "#:named"' do
+        let(:definition) { '#:named' }
+        it { is_expected.to be true }
+      end
+
+      context 'given anything else' do
+        let(:definition) { 'hel#o' }
+        it { is_expected.to be false }
+      end
+    end
+
     describe '.match?' do
       context 'given a string definition' do
         let(:definition) { 'some-string' }

--- a/spec/route_segment_spec.rb
+++ b/spec/route_segment_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+module CottonTail
+  describe RouteSegment do
+    subject(:segment) { described_class.new(definition) }
+
+    describe '.match?' do
+      context 'given a string definition' do
+        let(:definition) { 'some-string' }
+
+        it 'matches on string equality' do
+          expect { segment.match?('some-string').to be true }
+
+          expect { segment.match?('anything-else').to be false }
+          expect { segment.match?(nil).to be false }
+          expect { segment.match?(1).to be false }
+          expect { segment.match?({}).to be false }
+        end
+      end
+
+      context 'given an anonymous single wildcard definition' do
+        let(:definition) { '*' }
+
+        it 'matches any non-empty string without a "." character' do
+          expect { segment.match?('any string').to be true }
+
+          expect { segment.match?('my.string').to be false }
+          expect { segment.match?('').to be false }
+          expect { segment.match?(nil).to be false }
+          expect { segment.match?(1).to be false }
+          expect { segment.match?({}).to be false }
+        end
+      end
+
+      context 'given an anonymous group wildcard definition' do
+        let(:definition) { '#' }
+
+        it 'matches any non-empty string' do
+          expect { segment.match?('any string').to be true }
+          expect { segment.match?('any.string.value').to be true }
+
+          expect { segment.match?('').to be false }
+          expect { segment.match?(nil).to be false }
+          expect { segment.match?(1).to be false }
+          expect { segment.match?({}).to be false }
+        end
+      end
+
+      context 'given a named single wildcard definition' do
+        let(:definition) { '*:foo' }
+
+        it 'matches any non-empty string without a "." character' do
+          expect { segment.match?('any string').to be true }
+
+          expect { segment.match?('my.string').to be false }
+          expect { segment.match?('').to be false }
+          expect { segment.match?(nil).to be false }
+          expect { segment.match?(1).to be false }
+          expect { segment.match?({}).to be false }
+        end
+      end
+
+      context 'given a named wildcard definition' do
+        let(:definition) { '#:foo' }
+
+        it 'matches any non-empty string' do
+          expect { segment.match?('any string').to be true }
+          expect { segment.match?('any.string.value').to be true }
+
+          expect { segment.match?('').to be false }
+          expect { segment.match?(nil).to be false }
+          expect { segment.match?(1).to be false }
+          expect { segment.match?({}).to be false }
+        end
+      end
+    end
+  end
+end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -59,6 +59,8 @@ module CottonTail
             it 'behaves as expected' do
               expect(route.match?('c.d')).to be true
               expect(route.match?('a.b.c.d')).to be true
+              expect(route.match?('d')).to be true
+
               expect(route.match?('d.e')).to be false
               expect(route.match?('a.b.c')).to be false
             end

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -73,16 +73,22 @@ module CottonTail
       context 'given an exchange_type: :topic' do
         let(:opts) { { exchange_type: :topic } }
 
-        context 'given a pattern that is all wildcards' do
+        context 'given a pattern that is all single wildcards' do
           let(:pattern) { '*:domain.*:resource.*:action' }
 
           it { is_expected.to contain_exactly('domain', 'resource', 'action') }
 
           it 'matches as expected' do
-            expect(route.match? 'company.users.create').to be true
-            expect(route.match? 'company.users.create.friend').to be false
-            expect(route.match? 'company.users').to be false
+            expect(route.match?('company.users.create')).to be true
+            expect(route.match?('company.users.create.friend')).to be false
+            expect(route.match?('company.users')).to be false
           end
+        end
+
+        context 'given a pattern with mixed wildcards' do
+          let(:pattern) { '*:domain.#:resource_path.describe' }
+
+          it { is_expected.to contain_exactly('domain', 'resource_path') }
         end
 
         context 'given a pattern this with some wildcards' do

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -101,6 +101,38 @@ module CottonTail
       end
     end
 
+    describe '.binding' do
+      subject { route.binding }
+
+      context 'given an exchange_type: :topic' do
+        let(:opts) { { exchange_type: :topic } }
+
+        context 'given a pattern that is all single wildcards' do
+          let(:pattern) { '*:domain.*:resource.*:action' }
+
+          it { is_expected.to eql('*.*.*') }
+        end
+
+        context 'given a pattern that is mixed wildcards' do
+          let(:pattern) { '*:domain.#:resource.*:action' }
+
+          it { is_expected.to eql('*.#.*') }
+        end
+
+        context 'given mixed literals and wildcards' do
+          let(:pattern) { 'company.*:resource.#' }
+
+          it { is_expected.to eql('company.*.#') }
+        end
+
+        context 'given a simple string' do
+          let(:pattern) { 'company.users.add' }
+
+          it { is_expected.to eql pattern }
+        end
+      end
+    end
+
     describe '.extract_params' do
       subject { route.extract_params routing_key }
 

--- a/spec/route_spec.rb
+++ b/spec/route_spec.rb
@@ -66,5 +66,31 @@ module CottonTail
         end
       end
     end
+
+    describe '.wildcard_names' do
+      subject { route.wildcard_names }
+
+      context 'given an exchange_type: :topic' do
+        let(:opts) { { exchange_type: :topic } }
+
+        context 'given a pattern that is all wildcards' do
+          let(:pattern) { '*:domain.*:resource.*:action' }
+
+          it { is_expected.to contain_exactly('domain', 'resource', 'action') }
+
+          it 'matches as expected' do
+            expect(route.match? 'company.users.create').to be true
+            expect(route.match? 'company.users.create.friend').to be false
+            expect(route.match? 'company.users').to be false
+          end
+        end
+
+        context 'given a pattern this with some wildcards' do
+          let(:pattern) { 'my-domain.*:resource.*:action' }
+
+          it { is_expected.to contain_exactly('resource', 'action') }
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds the ability to add names to wildcard segments of AMQP routing_keys. The named values are extracted and passed through to the message handlers in the `Request.properties`.