### PR TITLE
Add App#stop and Queue::Supervisor#stop for graceful shutdown

### DIFF
--- a/lib/cotton_tail/app.rb
+++ b/lib/cotton_tail/app.rb
@@ -32,8 +32,17 @@ module CottonTail
     end
 
     def stop
-      supervisors.map(&:stop)
-      @connection.close
+      supervisors.each do |sup|
+        sup.stop
+      rescue StandardError => e
+        warn "Error stopping supervisor: #{e.message}"
+      end
+
+      begin
+        @connection.close unless @connection.closed?
+      rescue StandardError => e
+        warn "Error closing connection: #{e.message}"
+      end
     end
 
     def routes

--- a/lib/cotton_tail/app.rb
+++ b/lib/cotton_tail/app.rb
@@ -31,6 +31,11 @@ module CottonTail
       sleep 0.01 while running?
     end
 
+    def stop
+      supervisors.map(&:stop)
+      @connection.close
+    end
+
     def routes
       @routes ||= DSL::Routes.new(**@dependencies)
     end

--- a/lib/cotton_tail/queue/supervisor.rb
+++ b/lib/cotton_tail/queue/supervisor.rb
@@ -23,6 +23,13 @@ module CottonTail
         thread.alive?
       end
 
+      # Gracefully stop the supervisor: prevent further messages and wait for
+      # the processing thread to finish.
+      def stop
+        @queue.close
+        thread.join
+      end
+
       private
 
       def thread

--- a/lib/cotton_tail/queue/supervisor.rb
+++ b/lib/cotton_tail/queue/supervisor.rb
@@ -26,8 +26,15 @@ module CottonTail
       # Gracefully stop the supervisor: prevent further messages and wait for
       # the processing thread to finish.
       def stop
-        @queue.close
-        thread.join
+        return unless running?
+
+        begin
+          @queue.close
+        rescue StandardError => e
+          warn "Error closing queue: #{e.message}"
+        end
+
+        thread.join if thread.alive?
       end
 
       private

--- a/spec/unit/cotton_tail/queue/supervisor_spec.rb
+++ b/spec/unit/cotton_tail/queue/supervisor_spec.rb
@@ -26,6 +26,18 @@ module CottonTail
           expect { start }.to perform_under(0.1).sec
         end
       end
+
+      describe '.stop' do
+        before { supervisor.start }
+
+        it 'stops the processing thread' do
+          expect(supervisor.running?).to be true
+
+          supervisor.stop
+
+          expect(supervisor.running?).to be false
+        end
+      end
     end
   end
 end


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method to gracefully stop the application and its supervisors, ensuring all processing completes and connections are closed.

- **Tests**
	- Added integration and unit tests to verify the correct shutdown behavior of the application and supervisors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->